### PR TITLE
Activity APIs

### DIFF
--- a/OutTheGC/Endpoints/ActivityEndpoint.cs
+++ b/OutTheGC/Endpoints/ActivityEndpoint.cs
@@ -1,11 +1,140 @@
-﻿using System;
-namespace OutTheGC.Endpoints
+﻿using OutTheGC.Models;
+using OutTheGC.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace OutTheGC.Endpoints;
+
+public static class ActivityEndpoint
 {
-	public class ActivityEndpoint
+	public static void MapActivityEndpoints(this IEndpointRouteBuilder routes)
 	{
-		public ActivityEndpoint()
-		{
-		}
-	}
+        var group = routes.MapGroup("").WithTags(nameof(Activity));
+
+        group.MapGet("/activity/{activityId}", async (IActivityService activityService, Guid activityId) =>
+        {
+            var singleActivity = await activityService.GetSingleActivityAsync(activityId);
+
+            if (singleActivity == null)
+            {
+                return Results.NotFound(new
+                {
+                    error = "The activity does not exist."
+                });
+            }
+
+            return Results.Ok(new
+            {
+                singleActivity.Id,
+                singleActivity.Title,
+                singleActivity.Notes,
+                singleActivity.Location,
+                singleActivity.Date,
+                singleActivity.Duration,
+                singleActivity.Cost,
+                singleActivity.Category,
+                singleActivity.WebsiteUrl,
+                User = new
+                {
+                    singleActivity.User.FullName
+                },
+                singleActivity.CreatedAt,
+                singleActivity.UpdatedAt,
+                Comments = singleActivity.Comments.Select(sa => new
+                {
+                    User = new
+                    {
+                        sa.User.FullName
+                    },
+                    sa.Content,
+                    sa.CreatedAt,
+                    sa.UpdatedAt
+                })
+            });
+        })
+        .WithOpenApi()
+        .Produces<List<Trip>>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPost("/activity", async (IActivityService activityService, Activity newActivity) =>
+        {
+            var activityToAdd = await activityService.CreateActivityAsync(newActivity);
+
+            return Results.Created($"/activity/{activityToAdd.Id}", activityToAdd);
+        })
+        .WithOpenApi()
+        .Produces<Trip>(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPut("/activity/{activityId}", async (IActivityService activityService, Guid activityId, Activity updatedActivity) =>
+        {
+            var activityToUpdate = await activityService.UpdateActivityAsync(activityId, updatedActivity);
+
+            if (activityToUpdate == null)
+            {
+                return Results.NotFound(new
+                {
+                    error = "The activity does not exist."
+                });
+            }
+
+            return Results.Ok(new { message = "Activity information has been updated." });
+        })
+        .WithOpenApi()
+        .Produces<User>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status204NoContent);
+
+        group.MapDelete("/activity/{activityId}", async (IActivityService activityService, Guid activityId) =>
+        {
+            var activityToDelete = await activityService.DeleteActivityAsync(activityId);
+
+            if (activityToDelete == null)
+            {
+                return Results.NotFound(new
+                {
+                    error = "The activity does not exist."
+                });
+            }
+
+            return Results.Ok(new { nessage = "Activity has been deleted." });
+        })
+        .WithOpenApi()
+        .Produces<Trip>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status204NoContent);
+
+        group.MapGet("/activity/{tripId}/search", async (IActivityService activityService, Guid tripId, string searchInput) =>
+        {
+            List<Activity> searchResults = await activityService.SearchActivityAsync(tripId, searchInput);
+
+            if (!searchResults.Any())
+            {
+                return Results.NotFound(new
+                {
+                    error = $"{searchInput} is not found!"
+                });
+            }
+
+            return Results.Ok(searchResults.Select(sr => new
+            {
+                sr.Id,
+                sr.Title,
+                sr.Notes,
+                sr.Location,
+                sr.Date,
+                sr.Duration,
+                sr.Cost,
+                sr.CategoryId,
+                sr.Category,
+                sr.WebsiteUrl,
+                User = new
+                {
+                    sr.User.Id,
+                    sr.User.FullName,
+                    sr.User.ImageUrl
+                },
+            }));
+        })
+        .WithOpenApi()
+        .Produces<List<Trip>>(StatusCodes.Status200OK);
+    }
 }
 

--- a/OutTheGC/Endpoints/TripEndpoint.cs
+++ b/OutTheGC/Endpoints/TripEndpoint.cs
@@ -46,7 +46,7 @@ public static class TripEndpoint
                     p.Email,
                     p.ImageUrl,
                     p.Uid
-                }),
+                })
             }));
         })
         .WithOpenApi()
@@ -93,6 +93,25 @@ public static class TripEndpoint
                     p.ImageUrl,
                     p.Uid
                 }),
+                Activities = trip.Activities.Select(a => new
+                {
+                    a.Id,
+                    a.Title,
+                    a.Notes,
+                    a.Location,
+                    a.Date,
+                    a.Duration,
+                    a.Cost,
+                    a.CategoryId,
+                    a.Category,
+                    a.WebsiteUrl,
+                    User = new
+                    {
+                        a.User.Id,
+                        a.User.FullName,
+                        a.User.ImageUrl
+                    },
+                })
             });
         })
         .WithOpenApi()
@@ -140,7 +159,10 @@ public static class TripEndpoint
 
 
             return Results.Ok(new { message = "Trip information has been updated." });
-        });
+        })
+        .WithOpenApi()
+        .Produces<User>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status204NoContent);
 
         group.MapDelete("/trip/{tripId}", async (ITripService tripService, Guid tripId) =>
         {

--- a/OutTheGC/Endpoints/TripEndpoint.cs
+++ b/OutTheGC/Endpoints/TripEndpoint.cs
@@ -122,7 +122,6 @@ public static class TripEndpoint
         {
             var addTrip = await tripService.CreateTripAsync(newTrip);
 
-
             if (addTrip == null)
             {
                 return Results.NotFound(new
@@ -148,15 +147,6 @@ public static class TripEndpoint
                     error = "The trip you wish to update does not exist"
                 });
             }
-
-            if (triptoUpdate.UserId == Guid.Empty)
-            {
-                return Results.BadRequest(new
-                {
-                    error = "You are not an owner of this trip"
-                });
-            }
-
 
             return Results.Ok(new { message = "Trip information has been updated." });
         })

--- a/OutTheGC/Interfaces/IActivityRepository.cs
+++ b/OutTheGC/Interfaces/IActivityRepository.cs
@@ -4,8 +4,6 @@ namespace OutTheGC.Interfaces;
 
 public interface IActivityRepository
 {
-	Task<List<Activity>> GetActivitiesAsync(Guid tripId);
-
 	Task<Activity> GetSingleActivityAsync(Guid activityId);
 
 	Task<Activity> CreateActivityAsync(Activity newActivity);

--- a/OutTheGC/Interfaces/IActivityService.cs
+++ b/OutTheGC/Interfaces/IActivityService.cs
@@ -4,8 +4,6 @@ namespace OutTheGC.Interfaces;
 
 public interface IActivityService
 {
-    Task<List<Activity>> GetActivitiesAsync(Guid tripId);
-
     Task<Activity> GetSingleActivityAsync(Guid activityId);
 
     Task<Activity> CreateActivityAsync(Activity newActivity);

--- a/OutTheGC/Program.cs
+++ b/OutTheGC/Program.cs
@@ -53,5 +53,6 @@ app.UseHttpsRedirection();
 
 app.MapUserEndpoints();
 app.MapTripEndpoints();
+app.MapActivityEndpoints();
 
 app.Run();

--- a/OutTheGC/Repositories/ActivityRepository.cs
+++ b/OutTheGC/Repositories/ActivityRepository.cs
@@ -14,29 +14,108 @@ public class ActivityRepository : IActivityRepository
 		dbContext = context;
 	}
 
-    public async Task<Activity> GetSingleActivityAsync(Guid activityId)
+    public async Task<Activity?> GetSingleActivityAsync(Guid activityId)
     {
-        throw new NotImplementedException();
+        return await dbContext.Activities
+                    .Include(a => a.Category)
+                    .Include(a => a.User)
+                    .Include(a => a.Comments)
+                    .SingleOrDefaultAsync(a => a.Id == activityId);
     }
 
     public async Task<Activity> CreateActivityAsync(Activity newActivity)
     {
-        throw new NotImplementedException();
+        var tripExists = await dbContext.Trips.AnyAsync(t => t.Id == newActivity.TripId);
+
+        var categoryExists = await dbContext.Categories.AnyAsync(c => c.Id == newActivity.CategoryId);
+
+        var userExists = await dbContext.Users.AnyAsync(c => c.Id == newActivity.UserId);
+
+        if (!tripExists || !categoryExists || !userExists)
+        {
+            // Build a meaningful error message
+            var errors = new List<string>();
+            if (!tripExists) errors.Add("Invalid TripId.");
+            if (!categoryExists) errors.Add("Invalid CategoryId.");
+            if (!userExists) errors.Add("Invalid UserId.");
+
+            throw new InvalidOperationException($"Activity creation failed: {string.Join(" ", errors)}");
+        }
+
+        Activity activityToAdd = new Activity
+        {
+            TripId = newActivity.TripId,
+            Title = newActivity.Title,
+            Notes = newActivity.Notes,
+            Location = newActivity.Location,
+            Date = newActivity.Date,
+            Duration = newActivity.Duration,
+            Cost = newActivity.Cost,
+            CategoryId = newActivity.CategoryId,
+            WebsiteUrl = newActivity.WebsiteUrl,
+            UserId = newActivity.UserId,
+            CreatedAt = DateTime.Now
+        };
+
+        dbContext.Activities.Add(activityToAdd);
+        await dbContext.SaveChangesAsync();
+        return activityToAdd;
     }
 
     public async Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity)
     {
-        throw new NotImplementedException();
+        var activityToUpdate = await dbContext.Activities.SingleOrDefaultAsync(a => a.Id == activityId);
+
+        if (activityToUpdate == null)
+        {
+            return null;
+        }
+
+        activityToUpdate.Title = updatedActivity.Title ?? activityToUpdate.Title;
+        activityToUpdate.Notes = updatedActivity.Notes ?? activityToUpdate.Notes;
+        activityToUpdate.Location = updatedActivity.Location ?? activityToUpdate.Location;
+        activityToUpdate.Date = updatedActivity.Date;
+        activityToUpdate.Duration = updatedActivity.Duration != 0 ? updatedActivity.Duration : activityToUpdate.Duration;
+        activityToUpdate.Cost = updatedActivity.Cost != 0 ? updatedActivity.Cost : activityToUpdate.Cost;
+        activityToUpdate.CategoryId = updatedActivity.CategoryId != Guid.Empty ? updatedActivity.CategoryId : activityToUpdate.CategoryId;
+        activityToUpdate.WebsiteUrl = updatedActivity.WebsiteUrl ?? activityToUpdate.WebsiteUrl;
+        activityToUpdate.UpdatedAt = DateTime.Now;
+
+        await dbContext.SaveChangesAsync();
+
+        return updatedActivity;
     }
 
     public async Task<Activity> DeleteActivityAsync(Guid activityId)
     {
-        throw new NotImplementedException();
+        var activityToDelete= await dbContext.Activities.SingleOrDefaultAsync(a => a.Id == activityId);
+
+        if (activityToDelete == null)
+        {
+            return null;
+        }
+
+        dbContext.Activities.Remove(activityToDelete);
+        await dbContext.SaveChangesAsync();
+        return activityToDelete;
     }
 
     public async Task<List<Activity>> SearchActivityAsync(Guid tripId, string searchInput)
     {
-        throw new NotImplementedException();
+        if (string.IsNullOrEmpty(searchInput))
+        {
+            return null;
+        }
+
+        var seachActivity = await dbContext.Activities
+            .Where(a => a.TripId == tripId)
+            .Where(a => a.Title.ToLower().Contains(searchInput.ToLower()) || a.Notes.ToLower().Contains(searchInput) || a.Category.Name.ToLower().Contains(searchInput))
+            .Include(a => a.Category)
+            .Include(a => a.User)
+            .Include(a => a.Comments)
+            .ToListAsync();
+
+        return seachActivity;
     }
 }
 

--- a/OutTheGC/Repositories/ActivityRepository.cs
+++ b/OutTheGC/Repositories/ActivityRepository.cs
@@ -1,6 +1,7 @@
 ﻿using OutTheGC.Interfaces;
 using OutTheGC.Models;
 using OutTheGC.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace OutTheGC.Repositories;
 
@@ -12,11 +13,6 @@ public class ActivityRepository : IActivityRepository
 	{
 		dbContext = context;
 	}
-
-    public async Task<List<Activity>> GetActivitiesAsync(Guid tripId)
-    {
-        throw new NotImplementedException();
-    }
 
     public async Task<Activity> GetSingleActivityAsync(Guid activityId)
     {

--- a/OutTheGC/Repositories/TripRepository.cs
+++ b/OutTheGC/Repositories/TripRepository.cs
@@ -33,9 +33,9 @@ public class TripRepository : ITripRepository
     public async Task<Trip?> GetTripsByIdAsync(Guid tripId)
     {
         return await dbContext.Trips
-            .Include(t => t.Owner)
             .Include(t => t.Activities)
             .Include(t => t.Participants)
+            .Include(t => t.Owner)
             .SingleOrDefaultAsync(t => t.Id == tripId);
     }
 

--- a/OutTheGC/Repositories/TripRepository.cs
+++ b/OutTheGC/Repositories/TripRepository.cs
@@ -78,7 +78,7 @@ public class TripRepository : ITripRepository
 
         if (triptoUpdate.UserId != ownerId)
         {
-            return new Trip { UserId = Guid.Empty };
+            throw new Exception("You are not the owner of this Trip!");
         }
 
         triptoUpdate.Title = updatedTrip.Title ?? triptoUpdate.Title;

--- a/OutTheGC/Services/ActivityService.cs
+++ b/OutTheGC/Services/ActivityService.cs
@@ -14,11 +14,6 @@ public class ActivityService : IActivityService
 		_activityRepository = activityRepository;
 	}
 
-    public async Task<List<Activity>> GetActivitiesAsync(Guid tripId)
-    {
-        return await _activityRepository.GetActivitiesAsync(tripId);
-    }
-
     public async Task<Activity> GetSingleActivityAsync(Guid activityId)
     {
         return await _activityRepository.GetSingleActivityAsync(activityId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Implemented the logic in the Activity Repository class to be used for the activity endpoints as well created and tested the CRUD activity endpoints. Further removed get all activities method from the activity repository layout as get single trip will include all the activities for that trip. Lastly, I updated error handling for updating a trip and made get single trip api include its activities.

## Related Issue
- #22 
- #23 
- #24 
- #25 
- #27

## Motivation and Context
The goal was to build CRUD operations for activity data handling in a way that is easy to update and maintain by keeping the code organized. The Repository Pattern was used to separate data access, logic, and APIs, making it easier to fix issues or add new features. This approach ensures the system is ready for real-world use and integrates well with other parts of the application. Further, my goal is to code efficiently and eliminate any redundant logic hence why the activity repository layout, the get single trip api, and the update trip api was adjusted.

## How Can This Be Tested?
**_Make sure you have pgAdmin and postgres configured and installed._**

1. Pull down repository
2. Run the below code to create connection to the database
```
dotnet user-secrets init
dotnet user-secrets set "OutTheGCDbConnectionString" "Host=localhost;Port=5432;Username=postgres;Password=<your_postgresql_password>;Database=OutTheGC"
```
3. Run `dotnet ef database update`
4. Run the application and test all the activity endpoints

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)