### PR TITLE
Category and Comment APIs

### DIFF
--- a/OutTheGC/Endpoints/CategoryEndpoint.cs
+++ b/OutTheGC/Endpoints/CategoryEndpoint.cs
@@ -1,11 +1,21 @@
-﻿using System;
-namespace OutTheGC.Endpoints
+﻿using OutTheGC.Models;
+using OutTheGC.Interfaces;
+
+namespace OutTheGC.Endpoints;
+
+public static class CategoryEndpoint
 {
-	public class CategoryEndpoint
+	public static void MapCategoryEndpoints(this IEndpointRouteBuilder routes)
 	{
-		public CategoryEndpoint()
-		{
-		}
-	}
+        var group = routes.MapGroup("").WithTags(nameof(Category));
+
+        group.MapGet("/categories", async (ICategoryService categoryService) =>
+        {
+            return await categoryService.GetCategoriesAsync();
+        })
+        .WithOpenApi()
+        .Produces<List<Category>>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+    }
 }
 

--- a/OutTheGC/Endpoints/CommentEndpoint.cs
+++ b/OutTheGC/Endpoints/CommentEndpoint.cs
@@ -1,11 +1,77 @@
-﻿using System;
-namespace OutTheGC.Endpoints
+﻿using OutTheGC.Models;
+using OutTheGC.Interfaces;
+
+namespace OutTheGC.Endpoints;
+
+public static class CommentEndpoint
 {
-	public class CommentEndpoint
+	public static void MapCommentEndpoints(this IEndpointRouteBuilder routes)
 	{
-		public CommentEndpoint()
-		{
-		}
-	}
+        var group = routes.MapGroup("").WithTags(nameof(Comment));
+
+        group.MapGet("/comment/{commentId}", async (ICommentService commentService, Guid commentId) =>
+        {
+            var singleComment = await commentService.GetSingleCommentAsync(commentId);
+
+            if (singleComment == null)
+            {
+                return Results.NotFound(new
+                {
+                    error = "The commentId entered is not valid"
+                });
+            }
+
+            return Results.Ok(singleComment);
+        })
+        .WithOpenApi()
+        .Produces<Trip>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPost("/comment", async (ICommentService commentService, Comment newComment) =>
+        {
+            var commentToAdd = await commentService.CreateCommentAsync(newComment);
+
+            return Results.Created($"/activity/{commentToAdd.Id}", commentToAdd);
+        })
+        .WithOpenApi()
+        .Produces<Trip>(StatusCodes.Status201Created)
+        .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPut("/comment/{commentId}", async (ICommentService commentService, Guid commentId, Comment updatedComment) =>
+        {
+            var commentToUpdate = await commentService.UpdateCommentAsync(commentId, updatedComment);
+
+            if (commentToUpdate == null)
+            {
+                return Results.NotFound(new
+                {
+                    error = "The comment does not exist."
+                });
+            }
+
+            return Results.Ok(new { message = "Comment information has been updated." });
+        })
+        .WithOpenApi()
+        .Produces<User>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status204NoContent);
+
+        group.MapDelete("/comment/{commentId}", async (ICommentService commentService, Guid commentId) =>
+        {
+            var commentToDelete = await commentService.DeleteCommentAsync(commentId);
+
+            if (commentToDelete == null)
+            {
+                return Results.NotFound(new
+                {
+                    error = "The comment does not exist."
+                });
+            }
+
+            return Results.Ok(new { message = "Comment has been deleted." });
+        })
+        .WithOpenApi()
+        .Produces<Trip>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status204NoContent);
+    }
 }
 

--- a/OutTheGC/Interfaces/ICommentRepository.cs
+++ b/OutTheGC/Interfaces/ICommentRepository.cs
@@ -4,8 +4,6 @@ namespace OutTheGC.Interfaces;
 
 public interface ICommentRepository
 {
-	Task<List<Comment>> GetCommentsAsync(Guid activityId);
-
 	Task<Comment> GetSingleCommentAsync(Guid commentId);
 
 	Task<Comment> CreateCommentAsync(Comment newComment);

--- a/OutTheGC/Interfaces/ICommentService.cs
+++ b/OutTheGC/Interfaces/ICommentService.cs
@@ -4,8 +4,6 @@ namespace OutTheGC.Interfaces;
 
 public interface ICommentService
 {
-    Task<List<Comment>> GetCommentsAsync(Guid activityId);
-
     Task<Comment> GetSingleCommentAsync(Guid commentId);
 
     Task<Comment> CreateCommentAsync(Comment newComment);

--- a/OutTheGC/Program.cs
+++ b/OutTheGC/Program.cs
@@ -55,5 +55,6 @@ app.MapUserEndpoints();
 app.MapTripEndpoints();
 app.MapActivityEndpoints();
 app.MapCategoryEndpoints();
+app.MapCommentEndpoints();
 
 app.Run();

--- a/OutTheGC/Program.cs
+++ b/OutTheGC/Program.cs
@@ -54,5 +54,6 @@ app.UseHttpsRedirection();
 app.MapUserEndpoints();
 app.MapTripEndpoints();
 app.MapActivityEndpoints();
+app.MapCategoryEndpoints();
 
 app.Run();

--- a/OutTheGC/Repositories/CategoryRepository.cs
+++ b/OutTheGC/Repositories/CategoryRepository.cs
@@ -1,6 +1,7 @@
 ﻿using OutTheGC.Models;
 using OutTheGC.Interfaces;
 using OutTheGC.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace OutTheGC.Repositories;
 
@@ -15,7 +16,7 @@ public class CategoryRepository : ICategoryRepository
 
     public async Task<List<Category>> GetCategoriesAsync()
 	{
-        throw new NotImplementedException();
+		return await dbContext.Categories.ToListAsync();
     }
 }
 

--- a/OutTheGC/Repositories/CommentRepository.cs
+++ b/OutTheGC/Repositories/CommentRepository.cs
@@ -1,6 +1,7 @@
 ﻿using OutTheGC.Data;
 using OutTheGC.Interfaces;
 using OutTheGC.Models;
+using Microsoft.EntityFrameworkCore;
 
 namespace OutTheGC.Repositories;
 
@@ -15,22 +16,68 @@ public class CommentRepository : ICommentRepository
 
     public async Task<Comment> GetSingleCommentAsync(Guid commentId)
     {
-        throw new NotImplementedException();
+        return await dbContext.Comments.Include(c => c.User).SingleOrDefaultAsync(c => c.Id == commentId);
     }
 
     public async Task<Comment> CreateCommentAsync(Comment newComment)
     {
-        throw new NotImplementedException();
+        var activityExists = await dbContext.Activities.AnyAsync(a => a.Id == newComment.ActivityId);
+
+        var userExists = await dbContext.Users.AnyAsync(c => c.Id == newComment.UserId);
+
+        if (!activityExists || !userExists)
+        {
+            var errors = new List<string>();
+            if (!activityExists) errors.Add("Invalid ActivityId.");
+            if (!userExists) errors.Add("Invalid UserId.");
+
+            throw new InvalidOperationException($"Comment failed to be created: {string.Join(" ", errors)}");
+        }
+
+        Comment commentToAdd = new Comment
+        {
+            UserId = newComment.UserId,
+            ActivityId = newComment.ActivityId,
+            Content = newComment.Content,
+            CreatedAt = DateTime.Now
+        };
+
+        dbContext.Comments.Add(commentToAdd);
+        await dbContext.SaveChangesAsync();
+
+        return commentToAdd;
     }
 
     public async Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment)
     {
-        throw new NotImplementedException();
+        var commentToUpdate = await dbContext.Comments.SingleOrDefaultAsync(c => c.Id == commentId);
+
+        if (commentToUpdate == null)
+        {
+            return null;
+        }
+
+        commentToUpdate.Content = updatedComment.Content ?? commentToUpdate.Content;
+        commentToUpdate.UpdatedAt = DateTime.Now;
+
+        await dbContext.SaveChangesAsync();
+
+        return commentToUpdate;
     }
 
     public async Task<Comment> DeleteCommentAsync(Guid commentId)
     {
-        throw new NotImplementedException();
+        var commentToDelete = await dbContext.Comments.SingleOrDefaultAsync(c => c.Id == commentId);
+
+        if (commentToDelete == null)
+        {
+            return null;
+        }
+
+        dbContext.Comments.Remove(commentToDelete);
+        await dbContext.SaveChangesAsync();
+
+        return commentToDelete;
     }
 }
 

--- a/OutTheGC/Repositories/CommentRepository.cs
+++ b/OutTheGC/Repositories/CommentRepository.cs
@@ -13,11 +13,6 @@ public class CommentRepository : ICommentRepository
 		dbContext = context;
 	}
 
-    public async Task<List<Comment>> GetCommentsAsync(Guid activityId)
-    {
-        throw new NotImplementedException();
-    }
-
     public async Task<Comment> GetSingleCommentAsync(Guid commentId)
     {
         throw new NotImplementedException();

--- a/OutTheGC/Services/CommentService.cs
+++ b/OutTheGC/Services/CommentService.cs
@@ -13,11 +13,6 @@ public class CommentService : ICommentService
 		_commentRepository = commentRepository;
 	}
 
-    public async Task<List<Comment>> GetCommentsAsync(Guid activityId)
-    {
-        return await _commentRepository.GetCommentsAsync(activityId);
-    }
-
     public async Task<Comment> GetSingleCommentAsync(Guid commentId)
     {
         return await _commentRepository.GetSingleCommentAsync(commentId);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Implemented the logic in the Comment Repository class to be used for the comment endpoints as well created and tested the CRUD comment endpoints. Then, implemented get all categories endpoint using its repository template layout. Further removed get all comments method from the comment repository layout as get single activity will include all the comments for that activity.

## Related Issue
- #30
- #34
- #35
- #36
- #37

## Motivation and Context
The goal was to build CRUD operations for comment data handling in a way that is easy to update and maintain by keeping the code organized. The Repository Pattern was used to separate data access, logic, and APIs, making it easier to fix issues or add new features. This approach ensures the system is ready for real-world use and integrates well with other parts of the application. Further, my goal is to code efficiently and eliminate any redundant logic hence why the comment repository layout was adjusted.

## How Can This Be Tested?
**_Make sure you have pgAdmin and postgres configured and installed._**

1. Pull down repository
2. Run the below code to create connection to the database
```
dotnet user-secrets init
dotnet user-secrets set "OutTheGCDbConnectionString" "Host=localhost;Port=5432;Username=postgres;Password=<your_postgresql_password>;Database=OutTheGC"
```
3. Run `dotnet ef database update`
4. Run the application and test all the comment and categories endpoints

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)