### PR TITLE
Bug Fix

### DIFF
--- a/OutTheGC/Endpoints/CommentEndpoint.cs
+++ b/OutTheGC/Endpoints/CommentEndpoint.cs
@@ -21,7 +21,20 @@ public static class CommentEndpoint
                 });
             }
 
-            return Results.Ok(singleComment);
+            return Results.Ok(new
+            {
+                singleComment.Id,
+                singleComment.UserId,
+                User = new
+                {
+                    singleComment.User.Id,
+                    singleComment.User.FullName
+                },
+                singleComment.ActivityId,
+                singleComment.Content,
+                singleComment.CreatedAt,
+                singleComment.UpdatedAt
+            });
         })
         .WithOpenApi()
         .Produces<Trip>(StatusCodes.Status200OK)

--- a/OutTheGC/Endpoints/UserEndpoint.cs
+++ b/OutTheGC/Endpoints/UserEndpoint.cs
@@ -67,9 +67,9 @@ public static class UserEndpoint
         .Produces<User>(StatusCodes.Status201Created)
         .Produces(StatusCodes.Status400BadRequest);
 
-        group.MapPut("/user/{userId}", async (IUserService userService, Guid id, User existingUser) =>
+        group.MapPut("/user/{userId}", async (IUserService userService, Guid userId, User existingUser) =>
         {
-            var userToUpdate = await userService.UpdateUserAsync(id, existingUser);
+            var userToUpdate = await userService.UpdateUserAsync(userId, existingUser);
 
             if (userToUpdate == null)
             {
@@ -82,9 +82,9 @@ public static class UserEndpoint
         .Produces<User>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status204NoContent);
 
-        group.MapDelete("/user/{userId}", async (IUserService userService, Guid id) =>
+        group.MapDelete("/user/{userId}", async (IUserService userService, Guid userId) =>
         {
-            var userToDelete = await userService.DeleteUserAsync(id);
+            var userToDelete = await userService.DeleteUserAsync(userId);
 
             if (userToDelete == null)
             {

--- a/OutTheGC/Endpoints/UserEndpoint.cs
+++ b/OutTheGC/Endpoints/UserEndpoint.cs
@@ -39,7 +39,7 @@ public static class UserEndpoint
         .Produces<User>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status404NotFound);
 
-        group.MapGet("/user/{userId}/exists", async (IUserService userService, string uid) =>
+        group.MapGet("/user/exists", async (IUserService userService, string uid) =>
         {
             return await userService.CheckUserExistenceAsync(uid);
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Adjusted check user existence API endpoint to remove unnecessary path variable, renamed the variable being passed to the update and delete user endpoint to match what is in the path variable for the URI, and adjusted the single comment API to only return the user's id and full name.

## Related Issue
- #52 

## Motivation and Context
The adjustments were made to enhance API consistency, clarity, and usability. Removing the unnecessary path variable from the Check User Existence endpoint simplifies the URI structure, reduces redundancy, and avoids bad request error. Renaming the variable in the Update and Delete User endpoints ensures alignment between the variable name and the URI path, avoiding an unnecessary bad request error. Finally, modifying the Single Comment API to only return the user's ID and full name streamlines the response, providing only the essential information needed for efficient handling of user-related data

## How Can This Be Tested?
**_Make sure you have pgAdmin and postgres configured and installed._**

1. Pull down repository
2. Run the below code to create connection to the database
```
dotnet user-secrets init
dotnet user-secrets set "OutTheGCDbConnectionString" "Host=localhost;Port=5432;Username=postgres;Password=<your_postgresql_password>;Database=OutTheGC"
```
3. Run `dotnet ef database update`
4. Run the application and test:

    -  GET /user/{userId}/exists
    - PUT /user/{userId}
    - DELETE /user/{userId}
    - GET /comment/commentId

To make sure that they operate as intended based on the description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)