### PR TITLE
Bug Fix 2

### DIFF
--- a/OutTheGC/Endpoints/ActivityEndpoint.cs
+++ b/OutTheGC/Endpoints/ActivityEndpoint.cs
@@ -109,7 +109,7 @@ public static class ActivityEndpoint
             {
                 return Results.NotFound(new
                 {
-                    error = $"{searchInput} is not found!"
+                    error = $"No search results found!"
                 });
             }
 

--- a/OutTheGC/Endpoints/TripEndpoint.cs
+++ b/OutTheGC/Endpoints/TripEndpoint.cs
@@ -42,6 +42,7 @@ public static class TripEndpoint
                 t.UpdatedAt,
                 Participants = t.Participants.Select(p => new
                 {
+                    p.Id,
                     p.FullName,
                     p.Email,
                     p.ImageUrl,
@@ -88,6 +89,7 @@ public static class TripEndpoint
                 trip.UpdatedAt,
                 Participants = trip.Participants.Select(p => new
                 {
+                    p.Id,
                     p.FullName,
                     p.Email,
                     p.ImageUrl,

--- a/OutTheGC/Repositories/ActivityRepository.cs
+++ b/OutTheGC/Repositories/ActivityRepository.cs
@@ -109,7 +109,7 @@ public class ActivityRepository : IActivityRepository
 
         var seachActivity = await dbContext.Activities
             .Where(a => a.TripId == tripId)
-            .Where(a => a.Title.ToLower().Contains(searchInput.ToLower()) || a.Notes.ToLower().Contains(searchInput) || a.Category.Name.ToLower().Contains(searchInput))
+            .Where(a => a.Title.ToLower().Contains(searchInput.ToLower()) || a.Notes.ToLower().Contains(searchInput.ToLower()) || a.Category.Name.ToLower().Contains(searchInput.ToLower()))
             .Include(a => a.Category)
             .Include(a => a.User)
             .Include(a => a.Comments)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- DELETE ALL COMMENTS BEFORE CREATING PULL REQUEST -->

## Description
Adjusted search trip activities API error message to be more generic, and adjusted the logic to allow category and notes to make it non case sensitive. Further, included participants Id in get trips and get single trips API.

## Related Issue
- #53 
- #54 

## Motivation and Context
By making the error message more generic, the intention is likely to provide clearer feedback to users without being overly specific, which can help avoid confusion. Adjusting the logic to make category and notes case-insensitive aims to reduce errors or inconsistencies when matching values, enhancing user experience. Lastly, including participant IDs in the "get trips" and "get single trips" APIs likely allows for more comprehensive data retrieval, enabling applications to access relevant participant information when querying trip details.

## How Can This Be Tested?
**_Make sure you have pgAdmin and postgres configured and installed._**

1. Pull down repository
2. Run the below code to create connection to the database
```
dotnet user-secrets init
dotnet user-secrets set "OutTheGCDbConnectionString" "Host=localhost;Port=5432;Username=postgres;Password=<your_postgresql_password>;Database=OutTheGC"
```
3. Run `dotnet ef database update`
4. Run the application and test:

    - GET /activity/{tripId}/search?searchInput
    - GET /trips?userId
    - GET /trip/{tripId}

To make sure that they operate as intended based on the description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)