### PR TITLE
Refactored MVP Endpoints

### DIFF
--- a/OutTheGC/Endpoints/ActivityEndpoint.cs
+++ b/OutTheGC/Endpoints/ActivityEndpoint.cs
@@ -41,6 +41,7 @@ public static class ActivityEndpoint
                 singleActivity.UpdatedAt,
                 Comments = singleActivity.Comments.Select(sa => new
                 {
+                    sa.Id,
                     User = new
                     {
                         sa.User.FullName

--- a/OutTheGC/Endpoints/ActivityEndpoint.cs
+++ b/OutTheGC/Endpoints/ActivityEndpoint.cs
@@ -83,9 +83,9 @@ public static class ActivityEndpoint
         .Produces<User>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status204NoContent);
 
-        group.MapDelete("/activity/{activityId}", async (IActivityService activityService, Guid activityId) =>
+        group.MapDelete("/activity/{activityId}", async (IActivityService activityService, Guid activityId, Guid userId) =>
         {
-            var activityToDelete = await activityService.DeleteActivityAsync(activityId);
+            var activityToDelete = await activityService.DeleteActivityAsync(activityId, userId);
 
             if (activityToDelete == null)
             {

--- a/OutTheGC/Endpoints/ActivityEndpoint.cs
+++ b/OutTheGC/Endpoints/ActivityEndpoint.cs
@@ -65,9 +65,9 @@ public static class ActivityEndpoint
         .Produces<Trip>(StatusCodes.Status201Created)
         .Produces(StatusCodes.Status404NotFound);
 
-        group.MapPut("/activity/{activityId}", async (IActivityService activityService, Guid activityId, Activity updatedActivity) =>
+        group.MapPut("/activity/{activityId}", async (IActivityService activityService, Guid activityId, Activity updatedActivity, Guid userId) =>
         {
-            var activityToUpdate = await activityService.UpdateActivityAsync(activityId, updatedActivity);
+            var activityToUpdate = await activityService.UpdateActivityAsync(activityId, updatedActivity, userId);
 
             if (activityToUpdate == null)
             {

--- a/OutTheGC/Endpoints/CommentEndpoint.cs
+++ b/OutTheGC/Endpoints/CommentEndpoint.cs
@@ -50,9 +50,9 @@ public static class CommentEndpoint
         .Produces<Trip>(StatusCodes.Status201Created)
         .Produces(StatusCodes.Status404NotFound);
 
-        group.MapPut("/comment/{commentId}", async (ICommentService commentService, Guid commentId, Comment updatedComment) =>
+        group.MapPut("/comment/{commentId}", async (ICommentService commentService, Guid commentId, Comment updatedComment, Guid userId) =>
         {
-            var commentToUpdate = await commentService.UpdateCommentAsync(commentId, updatedComment);
+            var commentToUpdate = await commentService.UpdateCommentAsync(commentId, updatedComment, userId);
 
             if (commentToUpdate == null)
             {
@@ -68,9 +68,9 @@ public static class CommentEndpoint
         .Produces<User>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status204NoContent);
 
-        group.MapDelete("/comment/{commentId}", async (ICommentService commentService, Guid commentId) =>
+        group.MapDelete("/comment/{commentId}", async (ICommentService commentService, Guid commentId, Guid userId) =>
         {
-            var commentToDelete = await commentService.DeleteCommentAsync(commentId);
+            var commentToDelete = await commentService.DeleteCommentAsync(commentId, userId);
 
             if (commentToDelete == null)
             {

--- a/OutTheGC/Endpoints/TripEndpoint.cs
+++ b/OutTheGC/Endpoints/TripEndpoint.cs
@@ -156,9 +156,9 @@ public static class TripEndpoint
         .Produces<User>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status204NoContent);
 
-        group.MapDelete("/trip/{tripId}", async (ITripService tripService, Guid tripId) =>
+        group.MapDelete("/trip/{tripId}", async (ITripService tripService, Guid tripId, Guid ownerId) =>
         {
-            var tripToDelete = await tripService.DeleteTripAsync(tripId);
+            var tripToDelete = await tripService.DeleteTripAsync(tripId, ownerId);
 
             if (tripToDelete == null)
             {
@@ -168,28 +168,37 @@ public static class TripEndpoint
                 });
             }
 
-            return Results.Ok(new { message = "Trip and all it has activities and comments have been deleted!" });
+            return Results.Ok(new { message = "Trip and all its activities and comments have been deleted!" });
 
         })
         .WithOpenApi()
         .Produces<Trip>(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status204NoContent);
 
-        group.MapDelete("/trip/{tripId}/user/{userId}", async (ITripService tripService, Guid tripId, Guid userId) =>
+        group.MapDelete("/trip/{tripId}/user/{userId}", async (ITripService tripService, Guid tripId, Guid userId, Guid ownerId) =>
         {
-            var userToDelete = await tripService.DeleteUserFromTripAsync(tripId, userId);
-
-            
+            var userToDelete = await tripService.DeleteUserFromTripAsync(tripId, userId, ownerId);
 
             if (userToDelete == null)
             {
                 return Results.NotFound(new
                 {
-                    error = "There is no trip with this user."
+                    error = "The trip or the user does not exist."
                 });
             }
 
             return Results.Ok(new { message = "User has been deleted from trip!" });
+
+        })
+        .WithOpenApi()
+        .Produces<Trip>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status204NoContent);
+
+        group.MapPost("/trip/{tripId}/user", async (ITripService tripService, Guid tripId, Guid userId, Guid ownerId) =>
+        {
+            var addParticipantToTrip = await tripService.AddUserToTripAsync(tripId, userId, ownerId);
+
+            return Results.Ok(new { message = "User has been added to trip!" });
 
         })
         .WithOpenApi()

--- a/OutTheGC/Interfaces/IActivityRepository.cs
+++ b/OutTheGC/Interfaces/IActivityRepository.cs
@@ -10,7 +10,7 @@ public interface IActivityRepository
 
 	Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity);
 
-	Task<Activity> DeleteActivityAsync(Guid activityId);
+	Task<Activity> DeleteActivityAsync(Guid activityId, Guid userId);
 
 	Task<List<Activity>> SearchActivityAsync(Guid tripId, string searchInput);
 }

--- a/OutTheGC/Interfaces/IActivityRepository.cs
+++ b/OutTheGC/Interfaces/IActivityRepository.cs
@@ -8,7 +8,7 @@ public interface IActivityRepository
 
 	Task<Activity> CreateActivityAsync(Activity newActivity);
 
-	Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity);
+	Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity, Guid userId);
 
 	Task<Activity> DeleteActivityAsync(Guid activityId, Guid userId);
 

--- a/OutTheGC/Interfaces/IActivityService.cs
+++ b/OutTheGC/Interfaces/IActivityService.cs
@@ -8,7 +8,7 @@ public interface IActivityService
 
     Task<Activity> CreateActivityAsync(Activity newActivity);
 
-    Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity);
+    Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity, Guid userId);
 
     Task<Activity> DeleteActivityAsync(Guid activityId, Guid userId);
 

--- a/OutTheGC/Interfaces/IActivityService.cs
+++ b/OutTheGC/Interfaces/IActivityService.cs
@@ -10,7 +10,7 @@ public interface IActivityService
 
     Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity);
 
-    Task<Activity> DeleteActivityAsync(Guid activityId);
+    Task<Activity> DeleteActivityAsync(Guid activityId, Guid userId);
 
     Task<List<Activity>> SearchActivityAsync(Guid tripId, string searchInput);
 }

--- a/OutTheGC/Interfaces/ICommentRepository.cs
+++ b/OutTheGC/Interfaces/ICommentRepository.cs
@@ -8,8 +8,8 @@ public interface ICommentRepository
 
 	Task<Comment> CreateCommentAsync(Comment newComment);
 
-	Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment);
+	Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment, Guid userId);
 
-	Task<Comment> DeleteCommentAsync(Guid commentId);
+	Task<Comment> DeleteCommentAsync(Guid commentId, Guid userId);
 }
 

--- a/OutTheGC/Interfaces/ICommentService.cs
+++ b/OutTheGC/Interfaces/ICommentService.cs
@@ -8,8 +8,8 @@ public interface ICommentService
 
     Task<Comment> CreateCommentAsync(Comment newComment);
 
-    Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment);
+    Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment, Guid userId);
 
-    Task<Comment> DeleteCommentAsync(Guid commentId);
+    Task<Comment> DeleteCommentAsync(Guid commentId, Guid userId);
 }
 

--- a/OutTheGC/Interfaces/ITripRepository.cs
+++ b/OutTheGC/Interfaces/ITripRepository.cs
@@ -12,8 +12,10 @@ public interface ITripRepository
 
 	Task<Trip> UpdateTripAsync(Guid tripId, Trip updatedTrip, Guid ownerId);
 
-	Task<Trip> DeleteTripAsync(Guid tripId);
+	Task<Trip> DeleteTripAsync(Guid tripId, Guid ownerId);
 
-	Task<UserTrip> DeleteUserFromTripAsync(Guid tripId, Guid userId);
+	Task<UserTrip> DeleteUserFromTripAsync(Guid tripId, Guid userId, Guid ownerId);
+
+	Task<UserTrip> AddUserToTripAsync(Guid tripId, Guid userId, Guid ownerId);
 }
 

--- a/OutTheGC/Interfaces/ITripService.cs
+++ b/OutTheGC/Interfaces/ITripService.cs
@@ -1,20 +1,21 @@
 ﻿using OutTheGC.Models;
 
-namespace OutTheGC.Interfaces
+namespace OutTheGC.Interfaces;
+
+public interface ITripService
 {
-	public interface ITripService
-	{
-        Task<List<Trip>> GetTripsAsync(Guid userId);
+    Task<List<Trip>> GetTripsAsync(Guid userId);
 
-        Task<Trip> GetTripsByIdAsync(Guid tripId);
+    Task<Trip> GetTripsByIdAsync(Guid tripId);
 
-        Task<Trip> CreateTripAsync(Trip newTrip);
+    Task<Trip> CreateTripAsync(Trip newTrip);
 
-        Task<Trip> UpdateTripAsync(Guid tripId, Trip updatedTrip, Guid ownerId);
+    Task<Trip> UpdateTripAsync(Guid tripId, Trip updatedTrip, Guid ownerId);
 
-        Task<Trip> DeleteTripAsync(Guid tripId);
+    Task<Trip> DeleteTripAsync(Guid tripId, Guid ownerId);
 
-        Task<UserTrip> DeleteUserFromTripAsync(Guid tripId, Guid userId);
-    }
+    Task<UserTrip> DeleteUserFromTripAsync(Guid tripId, Guid userId, Guid ownerId);
+
+    Task<UserTrip> AddUserToTripAsync(Guid tripId, Guid userId, Guid ownerId);
 }
 

--- a/OutTheGC/Repositories/ActivityRepository.cs
+++ b/OutTheGC/Repositories/ActivityRepository.cs
@@ -63,13 +63,18 @@ public class ActivityRepository : IActivityRepository
         return activityToAdd;
     }
 
-    public async Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity)
+    public async Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity, Guid userId)
     {
         var activityToUpdate = await dbContext.Activities.SingleOrDefaultAsync(a => a.Id == activityId);
 
         if (activityToUpdate == null)
         {
             return null;
+        }
+
+        if (activityToUpdate.UserId != userId)
+        {
+            throw new Exception("403 Forbidden: User is not authorized to update this activity");
         }
 
         activityToUpdate.Title = updatedActivity.Title ?? activityToUpdate.Title;
@@ -98,6 +103,7 @@ public class ActivityRepository : IActivityRepository
 
         var tripOwnerId = await dbContext.Trips.Where(t => t.Id == activityToDelete.TripId).Select(t => t.UserId).SingleOrDefaultAsync();
 
+        // If the user satisfy one of the conditions then it deletes the activity. If it does not satisfy any of the consitions, it throws the exception                             \
         if (activityToDelete.UserId != userId && tripOwnerId != userId)
         {
             throw new Exception("403 Forbidden: User is not authorized to delete this activity");

--- a/OutTheGC/Repositories/ActivityRepository.cs
+++ b/OutTheGC/Repositories/ActivityRepository.cs
@@ -2,6 +2,7 @@
 using OutTheGC.Models;
 using OutTheGC.Data;
 using Microsoft.EntityFrameworkCore;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace OutTheGC.Repositories;
 
@@ -86,13 +87,20 @@ public class ActivityRepository : IActivityRepository
         return updatedActivity;
     }
 
-    public async Task<Activity> DeleteActivityAsync(Guid activityId)
+    public async Task<Activity> DeleteActivityAsync(Guid activityId, Guid userId)
     {
-        var activityToDelete= await dbContext.Activities.SingleOrDefaultAsync(a => a.Id == activityId);
+        var activityToDelete = await dbContext.Activities.SingleOrDefaultAsync(a => a.Id == activityId);
 
         if (activityToDelete == null)
         {
             return null;
+        }
+
+        var tripOwnerId = await dbContext.Trips.Where(t => t.Id == activityToDelete.TripId).Select(t => t.UserId).SingleOrDefaultAsync();
+
+        if (activityToDelete.UserId != userId && tripOwnerId != userId)
+        {
+            throw new Exception("403 Forbidden: User is not authorized to delete this activity");
         }
 
         dbContext.Activities.Remove(activityToDelete);

--- a/OutTheGC/Repositories/CommentRepository.cs
+++ b/OutTheGC/Repositories/CommentRepository.cs
@@ -48,13 +48,18 @@ public class CommentRepository : ICommentRepository
         return commentToAdd;
     }
 
-    public async Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment)
+    public async Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment, Guid userId)
     {
         var commentToUpdate = await dbContext.Comments.SingleOrDefaultAsync(c => c.Id == commentId);
 
         if (commentToUpdate == null)
         {
             return null;
+        }
+
+        if (commentToUpdate.UserId != userId)
+        {
+            throw new Exception("403 Forbidden: User is not authorized to delete this activity");
         }
 
         commentToUpdate.Content = updatedComment.Content ?? commentToUpdate.Content;
@@ -65,7 +70,7 @@ public class CommentRepository : ICommentRepository
         return commentToUpdate;
     }
 
-    public async Task<Comment> DeleteCommentAsync(Guid commentId)
+    public async Task<Comment> DeleteCommentAsync(Guid commentId, Guid userId)
     {
         var commentToDelete = await dbContext.Comments.SingleOrDefaultAsync(c => c.Id == commentId);
 
@@ -74,6 +79,10 @@ public class CommentRepository : ICommentRepository
             return null;
         }
 
+        if (commentToDelete.UserId != userId)
+        {
+            throw new Exception("403 Forbidden: User is not authorized to delete this activity");
+        }
         dbContext.Comments.Remove(commentToDelete);
         await dbContext.SaveChangesAsync();
 

--- a/OutTheGC/Services/ActivityService.cs
+++ b/OutTheGC/Services/ActivityService.cs
@@ -29,9 +29,9 @@ public class ActivityService : IActivityService
         return await _activityRepository.UpdateActivityAsync(activityId, updatedActivity);
     }
 
-    public async Task<Activity> DeleteActivityAsync(Guid activityId)
+    public async Task<Activity> DeleteActivityAsync(Guid activityId, Guid userId)
     {
-        return await _activityRepository.DeleteActivityAsync(activityId);
+        return await _activityRepository.DeleteActivityAsync(activityId, userId);
     }
 
     public async Task<List<Activity>> SearchActivityAsync(Guid tripId, string searchInput)

--- a/OutTheGC/Services/ActivityService.cs
+++ b/OutTheGC/Services/ActivityService.cs
@@ -24,9 +24,9 @@ public class ActivityService : IActivityService
         return await _activityRepository.CreateActivityAsync(newActivity);
     }
 
-    public async Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity)
+    public async Task<Activity> UpdateActivityAsync(Guid activityId, Activity updatedActivity, Guid userId)
     {
-        return await _activityRepository.UpdateActivityAsync(activityId, updatedActivity);
+        return await _activityRepository.UpdateActivityAsync(activityId, updatedActivity, userId);
     }
 
     public async Task<Activity> DeleteActivityAsync(Guid activityId, Guid userId)

--- a/OutTheGC/Services/CommentService.cs
+++ b/OutTheGC/Services/CommentService.cs
@@ -23,14 +23,14 @@ public class CommentService : ICommentService
         return await _commentRepository.CreateCommentAsync(newComment);
     }
 
-    public async Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment)
+    public async Task<Comment> UpdateCommentAsync(Guid commentId, Comment updatedComment, Guid userId)
     {
-        return await _commentRepository.UpdateCommentAsync(commentId, updatedComment);
+        return await _commentRepository.UpdateCommentAsync(commentId, updatedComment, userId);
     }
 
-    public async Task<Comment> DeleteCommentAsync(Guid commentId)
+    public async Task<Comment> DeleteCommentAsync(Guid commentId, Guid userId)
     {
-        return await _commentRepository.DeleteCommentAsync(commentId);
+        return await _commentRepository.DeleteCommentAsync(commentId, userId);
     }
 }
 

--- a/OutTheGC/Services/TripService.cs
+++ b/OutTheGC/Services/TripService.cs
@@ -34,14 +34,19 @@ public class TripService : ITripService
         return await _tripRepository.UpdateTripAsync(tripId, updatedTrip, ownerId);
     }
 
-    public async Task<Trip> DeleteTripAsync(Guid tripId)
+    public async Task<Trip> DeleteTripAsync(Guid tripId, Guid ownerId)
     {
-        return await _tripRepository.DeleteTripAsync(tripId);
+        return await _tripRepository.DeleteTripAsync(tripId, ownerId);
     }
 
-    public async Task<UserTrip> DeleteUserFromTripAsync(Guid tripId, Guid userId)
+    public async Task<UserTrip> DeleteUserFromTripAsync(Guid tripId, Guid userId, Guid ownerId)
     {
-        return await _tripRepository.DeleteUserFromTripAsync(tripId, userId);
+        return await _tripRepository.DeleteUserFromTripAsync(tripId, userId, ownerId);
+    }
+
+    public async Task<UserTrip> AddUserToTripAsync(Guid tripId, Guid userId, Guid ownerId)
+    {
+        return await _tripRepository.AddUserToTripAsync(tripId, userId, ownerId);
     }
 }
 


### PR DESCRIPTION
## Description
Updated all of the update and delete endpoints for trips, activities, and comments to only allow the creator of the item to make changes to it. Further, added an endpoint to add a user to a trip by only the owner can complete this action as well as updated the endpoint that deletes a user from a trip to be only completed by the owner of the trip. 

## Related Issue
- #51 

## Motivation and Context
To enhance security and maintain data integrity, the update and delete endpoints for trips, activities, and comments were updated to allow only the creator to make changes. Additionally, endpoints for adding or removing users from a trip were modified so that only the trip owner can manage participants.

## How Can This Be Tested?
1. Pull down repository
2. Run the below code to create connection to the database
```
dotnet user-secrets init
dotnet user-secrets set "OutTheGCDbConnectionString" "Host=localhost;Port=5432;Username=postgres;Password=<your_postgresql_password>;Database=OutTheGC"
```
3. Run `dotnet ef database update`
4. Run the application and test all the PUT and DELETE requests for trips, activities, and comments as well as the add and delete user from a trip


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)